### PR TITLE
Fix in place modification of user request dictionary

### DIFF
--- a/polytope_mars/api.py
+++ b/polytope_mars/api.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import json
 import logging
@@ -59,6 +60,8 @@ class PolytopeMars:
                 request = json.loads(request)
             except ValueError:
                 raise ValueError("Request not in JSON format or python dictionary")  # noqa: E501
+        else:
+            request = copy.deepcopy(request)
 
         # expect a "feature" key in the request
         try:


### PR DESCRIPTION
### Description

While using polytope-mars, I just saw that my passed request dictionary got modified inplace, as some keys get `.pop()`-ed further down in the code.

What would you think about creating a deepcopy at the top of the `PolytopeMars.extract()` function? This way, we don't modify the dictionary passed by the user (which they might not suspect). Probably the performance impact of this should be fairly minimal?  If these request dictionaries can become quite large where this would be a concern, I'm happy to propose something more performant to fix it.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 