### PR TITLE
Fix exclusive upper bound in step range expansion

### DIFF
--- a/polytope_mars/api.py
+++ b/polytope_mars/api.py
@@ -383,7 +383,7 @@ class PolytopeMars:
                             steps = find_step_intervals(split[0], split[2], split[-1])
                             base_shapes.append(shapes.Select(k, steps))
                         else:
-                            expansion = list(range(int(split[0]), int(split[2]), int(split[-1])))
+                            expansion = list(range(int(split[0]), int(split[2]) + 1, int(split[-1])))
                             base_shapes.append(shapes.Select(k, expansion))
 
                 # List of individual values -> Union of Selects

--- a/polytope_mars/utils/datetimes.py
+++ b/polytope_mars/utils/datetimes.py
@@ -58,7 +58,7 @@ def find_step_intervals(step_start: str, step_end: str, step_freq: str):
 
     # if we have normal digit steps only, treat like before
     if step_start.isdigit() and step_end.isdigit() and step_freq.isdigit():
-        return list(range(int(step_start), int(step_end), int(step_freq)))
+        return list(range(int(step_start), int(step_end) + 1, int(step_freq)))
 
     step_start_pd_format = format_step_str_to_pd(step_start)
     step_end_pd_format = format_step_str_to_pd(step_end)

--- a/tests/test_datetimes.py
+++ b/tests/test_datetimes.py
@@ -1,7 +1,25 @@
-from polytope_mars.utils.datetimes import from_range_to_list_date
+from polytope_mars.utils.datetimes import find_step_intervals, from_range_to_list_date
 
 
 def test_from_range_to_list_date_spans_months():
     date_range = "20220130/to/20220202"
     expected = "20220130/20220131/20220201/20220202"
     assert from_range_to_list_date(date_range) == expected
+
+
+def test_find_step_intervals_inclusive_upper_bound():
+    """Step range 6/to/48/by/6 must include 48 (MARS convention: inclusive upper bound)."""
+    result = find_step_intervals("6", "48", "6")
+    assert result == [6, 12, 18, 24, 30, 36, 42, 48]
+
+
+def test_find_step_intervals_simple_range():
+    """Step range 0/to/10/by/2 must include 10."""
+    result = find_step_intervals("0", "10", "2")
+    assert result == [0, 2, 4, 6, 8, 10]
+
+
+def test_find_step_intervals_single_step():
+    """Step range 0/to/0/by/1 must return [0]."""
+    result = find_step_intervals("0", "0", "1")
+    assert result == [0]

--- a/tests/test_time_series.py
+++ b/tests/test_time_series.py
@@ -302,3 +302,12 @@ class TestHdateRequestConstruction:
         ]
         assert d["date"] == ["20240301"]
         assert "time" not in d
+
+    def test_generic_numeric_by_range_inclusive(self):
+        """Generic numeric axis with 'by' range must include upper bound."""
+        request = copy.deepcopy(self.request)
+        request["number"] = "2/to/10/by/2"
+        preq = self._build_request(request)
+        d = self._shapes_to_dict(preq)
+
+        assert d["number"] == [2, 4, 6, 8, 10]


### PR DESCRIPTION
### Description

`"step": "0/to/6/by/3"` returned `[0, 3]` instead of `[0, 3, 6]` because the upper bound was treated as exclusive. 
Two `range()` calls were missing the `+ 1` that all other range expansions in the codebase already had.

The `find_step_intervals` fix covers step ranges (e.g. `"step": "6/to/48/by/6"`), while the `api.py` fix covers generic numeric axes like `"number": "2/to/10/by/2"`.

Fixes #101

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 