### PR TITLE
Allow identifiers to be added in feature dictionary for timeseries

### DIFF
--- a/polytope_mars/features/timeseries.py
+++ b/polytope_mars/features/timeseries.py
@@ -25,7 +25,7 @@ class TimeSeries(Feature):
             self.axes = ["latitude", "longitude"]
 
         self.points = feature_config.pop("points", [])
-        self.identifiers = feature_config.pop("identifiers", None)
+        self.identifiers = feature_config.pop("labels", None)
 
         if "range" in feature_config:
             feature_config.pop("range")
@@ -107,7 +107,7 @@ class TimeSeries(Feature):
             raise ValueError("Timeseries must have only two values in points")
         if self.identifiers is not None and len(self.identifiers) != len(feature_config["points"]):
             raise ValueError(
-                f"Number of identifiers ({len(self.identifiers)}) must match "
+                f"Number of labels ({len(self.identifiers)}) must match "
                 f"number of points ({len(feature_config['points'])})"
             )
         if time_axis in request and "range" in feature_config:

--- a/polytope_mars/features/timeseries.py
+++ b/polytope_mars/features/timeseries.py
@@ -25,6 +25,7 @@ class TimeSeries(Feature):
             self.axes = ["latitude", "longitude"]
 
         self.points = feature_config.pop("points", [])
+        self.identifiers = feature_config.pop("identifiers", None)
 
         if "range" in feature_config:
             feature_config.pop("range")
@@ -33,19 +34,30 @@ class TimeSeries(Feature):
 
     def get_shapes(self):
         # Time-series is a squashed box from start_step to start_end for each point  # noqa: E501
+        if self.identifiers is not None:
+            point_shapes = [
+                shapes.Point(
+                    [self.axes[0], self.axes[1]],
+                    [[p[0], p[1]]],
+                    method="nearest",
+                    tag=identifier,
+                )
+                for p, identifier in zip(self.points, self.identifiers)
+            ]
+        else:
+            point_shapes = [
+                shapes.Point(
+                    [self.axes[0], self.axes[1]],
+                    [[p[0], p[1]]],
+                    method="nearest",
+                )
+                for p in self.points
+            ]
         return [
             shapes.Union(
                 [self.axes[0], self.axes[1]],
-                *[
-                    shapes.Point(
-                        [self.axes[0], self.axes[1]],
-                        [[p[0], p[1]]],
-                        method="nearest",  # noqa: E501
-                    )
-                    for p in self.points
-                ],
+                *point_shapes,
             ),
-            # shapes.Span("step", self.start_step, self.end_step),
         ]
 
     def incompatible_keys(self):
@@ -93,6 +105,11 @@ class TimeSeries(Feature):
 
         if len(feature_config["points"][0]) != 2:
             raise ValueError("Timeseries must have only two values in points")
+        if self.identifiers is not None and len(self.identifiers) != len(feature_config["points"]):
+            raise ValueError(
+                f"Number of identifiers ({len(self.identifiers)}) must match "
+                f"number of points ({len(feature_config['points'])})"
+            )
         if time_axis in request and "range" in feature_config:
             raise ValueError("Timeseries time_axis is overspecified in request")
         if time_axis not in request and "range" not in feature_config:  # noqa: E501

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -1,0 +1,510 @@
+"""Tests for the optional 'identifiers' field in the timeseries feature dictionary."""
+
+import copy
+from datetime import datetime, timedelta
+
+import pytest
+from conflator import Conflator
+from polytope_feature import shapes
+from polytope_feature.polytope import Request
+
+from polytope_mars.api import PolytopeMars
+from polytope_mars.config import PolytopeMarsConfig
+
+
+class TestIdentifiersValidation:
+    """Unit tests for identifiers parsing and validation (no data retrieval)."""
+
+    def setup_method(self):
+        today = datetime.today()
+        yesterday = today - timedelta(days=1)
+        self.date = yesterday.strftime("%Y%m%d")
+
+        self.request = {
+            "class": "od",
+            "stream": "enfo",
+            "type": "pf",
+            "date": self.date,
+            "time": "0000",
+            "levtype": "sfc",
+            "expver": "0001",
+            "domain": "g",
+            "param": "167",
+            "number": "1",
+            "feature": {
+                "type": "timeseries",
+                "points": [[-9.10, 38.78], [51.5, 6.5]],
+                "identifiers": ["Lisbon", "Dusseldorf"],
+                "time_axis": "step",
+                "axes": ["latitude", "longitude"],
+                "range": {"start": 0, "end": 3},
+            },
+        }
+
+        self.options = {
+            "axis_config": [
+                {
+                    "axis_name": "date",
+                    "transformations": [{"name": "merge", "other_axis": "time", "linkers": ["T", "00"]}],
+                },
+                {
+                    "axis_name": "values",
+                    "transformations": [
+                        {
+                            "name": "mapper",
+                            "type": "octahedral",
+                            "resolution": 1280,
+                            "axes": ["latitude", "longitude"],
+                        }
+                    ],
+                },
+                {"axis_name": "levelist", "transformations": [{"name": "type_change", "type": "str"}]},
+                {"axis_name": "latitude", "transformations": [{"name": "reverse", "is_reverse": True}]},
+                {"axis_name": "longitude", "transformations": [{"name": "cyclic", "range": [0, 360]}]},
+                {"axis_name": "step", "transformations": [{"name": "type_change", "type": "int"}]},
+                {"axis_name": "number", "transformations": [{"name": "type_change", "type": "int"}]},
+            ],
+            "compressed_axes_config": [
+                "longitude",
+                "latitude",
+                "levtype",
+                "step",
+                "date",
+                "domain",
+                "expver",
+                "param",
+                "class",
+                "stream",
+                "type",
+                "number",
+            ],
+            "pre_path": {
+                "class": "od",
+                "expver": "0001",
+                "levtype": "sfc",
+                "stream": "enfo",
+                "type": "pf",
+                "domain": "g",
+            },
+        }
+
+        conf = Conflator(app_name="polytope_mars", model=PolytopeMarsConfig).load()
+        self.cf = conf.model_dump()
+        self.cf["options"] = self.options
+
+    def _build_request_shapes(self, request):
+        """Build the polytope Request from a polytope-mars request dict (without data retrieval)."""
+        pm = PolytopeMars(self.cf)
+        request = copy.deepcopy(request)
+        feature_config = request.pop("feature")
+        feature_config_copy = feature_config.copy()
+        feature_type = feature_config["type"]
+
+        # Replicate the time_axis pre-processing from api.py
+        if feature_type == "timeseries":
+            if "axes" in feature_config:
+                if feature_config["axes"] == "step":
+                    del feature_config["axes"]
+                    del feature_config_copy["axes"]
+                    feature_config["time_axis"] = "step"
+                    feature_config_copy["time_axis"] = "step"
+
+        feature = pm._feature_factory(feature_type, feature_config, pm.conf)
+        feature.validate(request, feature_config_copy)
+        request = feature.parse(request, feature_config_copy)
+        s = pm._create_base_shapes(request, feature_type)
+        s.extend(feature.get_shapes())
+        return Request(*s), feature
+
+    # -- Basic acceptance tests --
+
+    def test_identifiers_accepted_in_feature_config(self):
+        """Identifiers field is accepted without error when count matches points."""
+        preq, feature = self._build_request_shapes(self.request)
+        assert feature.identifiers == ["Lisbon", "Dusseldorf"]
+
+    def test_identifiers_none_when_not_provided(self):
+        """When identifiers is omitted, feature.identifiers is None."""
+        request = copy.deepcopy(self.request)
+        del request["feature"]["identifiers"]
+        preq, feature = self._build_request_shapes(request)
+        assert feature.identifiers is None
+
+    def test_identifiers_single_point(self):
+        """Identifiers works with a single point."""
+        request = copy.deepcopy(self.request)
+        request["feature"]["points"] = [[48.0, 11.0]]
+        request["feature"]["identifiers"] = ["Munich"]
+        preq, feature = self._build_request_shapes(request)
+        assert feature.identifiers == ["Munich"]
+
+    def test_identifiers_many_points(self):
+        """Identifiers works with many points."""
+        request = copy.deepcopy(self.request)
+        points = [[-9.10, 38.78], [51.5, 6.5], [48.0, 11.0], [40.4, -3.7]]
+        identifiers = ["Lisbon", "Dusseldorf", "Munich", "Madrid"]
+        request["feature"]["points"] = points
+        request["feature"]["identifiers"] = identifiers
+        preq, feature = self._build_request_shapes(request)
+        assert feature.identifiers == identifiers
+
+    # -- Validation error tests --
+
+    def test_identifiers_mismatch_too_few(self):
+        """Raises ValueError when fewer identifiers than points."""
+        request = copy.deepcopy(self.request)
+        request["feature"]["identifiers"] = ["Lisbon"]  # only 1, but 2 points
+        with pytest.raises(ValueError, match="Number of identifiers"):
+            self._build_request_shapes(request)
+
+    def test_identifiers_mismatch_too_many(self):
+        """Raises ValueError when more identifiers than points."""
+        request = copy.deepcopy(self.request)
+        request["feature"]["identifiers"] = ["Lisbon", "Dusseldorf", "Munich"]  # 3, but 2 points
+        with pytest.raises(ValueError, match="Number of identifiers"):
+            self._build_request_shapes(request)
+
+    def test_identifiers_empty_list_with_points(self):
+        """Raises ValueError when identifiers is empty but points exist."""
+        request = copy.deepcopy(self.request)
+        request["feature"]["identifiers"] = []
+        with pytest.raises(ValueError, match="Number of identifiers"):
+            self._build_request_shapes(request)
+
+    # -- Shape construction tests --
+
+    def test_identifiers_passed_as_tag_to_point_shapes(self):
+        """Each identifier is passed as the tag kwarg to the corresponding shapes.Point."""
+        request = copy.deepcopy(self.request)
+        preq, feature = self._build_request_shapes(request)
+
+        # Find the Union shape (it covers latitude/longitude)
+        union_shape = None
+        for shape in preq.shapes:
+            if isinstance(shape, shapes.Union):
+                union_shape = shape
+                break
+
+        assert union_shape is not None, "Expected a Union shape for lat/lon points"
+
+        # The Union's internal shapes should be Points with tags
+        point_shapes = union_shape._shapes
+        assert len(point_shapes) == 2
+
+        # Check tags match identifiers
+        tags = [p.tag for p in point_shapes]
+        assert tags == ["Lisbon", "Dusseldorf"]
+
+    def test_no_identifiers_means_no_tags(self):
+        """When identifiers is not provided, Point shapes have tag=None."""
+        request = copy.deepcopy(self.request)
+        del request["feature"]["identifiers"]
+        preq, feature = self._build_request_shapes(request)
+
+        union_shape = None
+        for shape in preq.shapes:
+            if isinstance(shape, shapes.Union):
+                union_shape = shape
+                break
+
+        assert union_shape is not None
+        point_shapes = union_shape._shapes
+        for p in point_shapes:
+            assert p.tag is None
+
+    def test_identifiers_with_swapped_axes(self):
+        """Identifiers work correctly when axes are [longitude, latitude]."""
+        request = copy.deepcopy(self.request)
+        request["feature"]["axes"] = ["longitude", "latitude"]
+        request["feature"]["points"] = [[38.78, -9.10], [6.5, 51.5]]
+        request["feature"]["identifiers"] = ["Lisbon", "Dusseldorf"]
+        preq, feature = self._build_request_shapes(request)
+
+        union_shape = None
+        for shape in preq.shapes:
+            if isinstance(shape, shapes.Union):
+                union_shape = shape
+                break
+
+        assert union_shape is not None
+        point_shapes = union_shape._shapes
+        tags = [p.tag for p in point_shapes]
+        assert tags == ["Lisbon", "Dusseldorf"]
+
+    def test_identifiers_numeric_values(self):
+        """Identifiers can be numeric (e.g. station IDs)."""
+        request = copy.deepcopy(self.request)
+        request["feature"]["identifiers"] = [12345, 67890]
+        preq, feature = self._build_request_shapes(request)
+
+        union_shape = None
+        for shape in preq.shapes:
+            if isinstance(shape, shapes.Union):
+                union_shape = shape
+                break
+
+        point_shapes = union_shape._shapes
+        tags = [p.tag for p in point_shapes]
+        assert tags == [12345, 67890]
+
+    def test_identifiers_not_allowed_without_points(self):
+        """If points is empty but identifiers is provided, validation fails."""
+        request = copy.deepcopy(self.request)
+        request["feature"]["points"] = []
+        request["feature"]["identifiers"] = ["Lisbon"]
+        # This should fail because points is empty but identifiers has values
+        # The parse step will fail because points[0] doesn't exist
+        with pytest.raises((ValueError, IndexError)):
+            self._build_request_shapes(request)
+
+
+class TestIdentifiersIntegration:
+    """Integration tests that verify the full extract pipeline accepts identifiers.
+
+    These tests use the PolytopeMars API but may skip actual data retrieval
+    if gribjump is not available.
+    """
+
+    def setup_method(self):
+        today = datetime.today()
+        yesterday = today - timedelta(days=1)
+        self.date = yesterday.strftime("%Y%m%d")
+
+        self.options = {
+            "axis_config": [
+                {
+                    "axis_name": "date",
+                    "transformations": [{"name": "merge", "other_axis": "time", "linkers": ["T", "00"]}],
+                },
+                {
+                    "axis_name": "values",
+                    "transformations": [
+                        {
+                            "name": "mapper",
+                            "type": "octahedral",
+                            "resolution": 1280,
+                            "axes": ["latitude", "longitude"],
+                        }
+                    ],
+                },
+                {"axis_name": "levelist", "transformations": [{"name": "type_change", "type": "str"}]},
+                {"axis_name": "latitude", "transformations": [{"name": "reverse", "is_reverse": True}]},
+                {"axis_name": "longitude", "transformations": [{"name": "cyclic", "range": [0, 360]}]},
+                {"axis_name": "step", "transformations": [{"name": "type_change", "type": "int"}]},
+                {"axis_name": "number", "transformations": [{"name": "type_change", "type": "int"}]},
+            ],
+            "compressed_axes_config": [
+                "longitude",
+                "latitude",
+                "levtype",
+                "step",
+                "date",
+                "domain",
+                "expver",
+                "param",
+                "class",
+                "stream",
+                "type",
+                "number",
+            ],
+            "pre_path": {
+                "class": "od",
+                "expver": "0001",
+                "levtype": "sfc",
+                "stream": "enfo",
+                "type": "pf",
+                "domain": "g",
+            },
+        }
+
+        conf = Conflator(app_name="polytope_mars", model=PolytopeMarsConfig).load()
+        self.cf = conf.model_dump()
+        self.cf["options"] = self.options
+
+    def test_extract_with_identifiers(self):
+        """Full extract pipeline accepts identifiers without error."""
+        request = {
+            "class": "od",
+            "stream": "enfo",
+            "type": "pf",
+            "date": self.date,
+            "time": "0000",
+            "levtype": "sfc",
+            "expver": "0001",
+            "domain": "g",
+            "param": "167",
+            "number": "1",
+            "feature": {
+                "type": "timeseries",
+                "points": [[-9.10, 38.78], [51.5, 6.5]],
+                "identifiers": ["Lisbon", "Dusseldorf"],
+                "time_axis": "step",
+                "axes": ["latitude", "longitude"],
+                "range": {"start": 0, "end": 3},
+            },
+        }
+        try:
+            result = PolytopeMars(self.cf).extract(request)
+            assert result is not None
+        except Exception as e:
+            # If gribjump/FDB is not available, the test should not fail on that
+            if "GribJump" in str(type(e).__name__) or "fdb" in str(e).lower() or "gribjump" in str(e).lower():
+                pytest.skip("GribJump/FDB not available for integration test")
+            raise
+
+    def test_extract_without_identifiers_still_works(self):
+        """Full extract pipeline still works when identifiers is not provided."""
+        request = {
+            "class": "od",
+            "stream": "enfo",
+            "type": "pf",
+            "date": self.date,
+            "time": "0000",
+            "levtype": "sfc",
+            "expver": "0001",
+            "domain": "g",
+            "param": "167",
+            "number": "1",
+            "feature": {
+                "type": "timeseries",
+                "points": [[-9.10, 38.78]],
+                "time_axis": "step",
+                "axes": ["latitude", "longitude"],
+                "range": {"start": 0, "end": 3},
+            },
+        }
+        try:
+            result = PolytopeMars(self.cf).extract(request)
+            assert result is not None
+        except Exception as e:
+            if "GribJump" in str(type(e).__name__) or "fdb" in str(e).lower() or "gribjump" in str(e).lower():
+                pytest.skip("GribJump/FDB not available for integration test")
+            raise
+
+    def test_merged_points_duplicate_coverages(self):
+        """When two points snap to the same grid cell, each identifier gets its own coverage."""
+        request = {
+            "class": "od",
+            "stream": "enfo",
+            "type": "pf",
+            "date": self.date,
+            "time": "0000",
+            "levtype": "sfc",
+            "expver": "0001",
+            "domain": "g",
+            "param": "167",
+            "number": "1",
+            "feature": {
+                "type": "timeseries",
+                # Two points very close together (snap to same grid point) + one distinct
+                "points": [[-9.10, 38.78], [-9.11, 38.79], [51.5, 6.5]],
+                "identifiers": ["Lisbon_StationA", "Lisbon_StationB", "Dusseldorf"],
+                "time_axis": "step",
+                "axes": ["latitude", "longitude"],
+                "range": {"start": 0, "end": 3},
+            },
+        }
+        try:
+            result = PolytopeMars(self.cf).extract(request)
+        except Exception as e:
+            if "GribJump" in str(type(e).__name__) or "fdb" in str(e).lower() or "gribjump" in str(e).lower():
+                pytest.skip("GribJump/FDB not available for integration test")
+            raise
+
+        coverages = result["coverages"]
+
+        # Should get 3 coverages even though only 2 unique grid points
+        assert len(coverages) == 3
+
+        # Collect identifiers from all coverages
+        identifiers = [c["mars:metadata"]["identifier"] for c in coverages]
+        assert "Lisbon_StationA" in identifiers
+        assert "Lisbon_StationB" in identifiers
+        assert "Dusseldorf" in identifiers
+
+    def test_merged_points_same_data(self):
+        """Coverages for merged points have identical data values."""
+        request = {
+            "class": "od",
+            "stream": "enfo",
+            "type": "pf",
+            "date": self.date,
+            "time": "0000",
+            "levtype": "sfc",
+            "expver": "0001",
+            "domain": "g",
+            "param": "167",
+            "number": "1",
+            "feature": {
+                "type": "timeseries",
+                # Two points that will snap to the same grid point
+                "points": [[-9.10, 38.78], [-9.11, 38.79]],
+                "identifiers": ["StationA", "StationB"],
+                "time_axis": "step",
+                "axes": ["latitude", "longitude"],
+                "range": {"start": 0, "end": 3},
+            },
+        }
+        try:
+            result = PolytopeMars(self.cf).extract(request)
+        except Exception as e:
+            if "GribJump" in str(type(e).__name__) or "fdb" in str(e).lower() or "gribjump" in str(e).lower():
+                pytest.skip("GribJump/FDB not available for integration test")
+            raise
+
+        coverages = result["coverages"]
+        assert len(coverages) == 2
+
+        # Both coverages should have the same coordinates (same grid point)
+        lat_a = coverages[0]["domain"]["axes"]["latitude"]["values"]
+        lat_b = coverages[1]["domain"]["axes"]["latitude"]["values"]
+        lon_a = coverages[0]["domain"]["axes"]["longitude"]["values"]
+        lon_b = coverages[1]["domain"]["axes"]["longitude"]["values"]
+        assert lat_a == lat_b
+        assert lon_a == lon_b
+
+        # Both coverages should have identical data values
+        param_key = list(coverages[0]["ranges"].keys())[0]
+        values_a = coverages[0]["ranges"][param_key]["values"]
+        values_b = coverages[1]["ranges"][param_key]["values"]
+        assert values_a == values_b
+
+        # But different identifiers
+        id_a = coverages[0]["mars:metadata"]["identifier"]
+        id_b = coverages[1]["mars:metadata"]["identifier"]
+        assert id_a != id_b
+        assert {id_a, id_b} == {"StationA", "StationB"}
+
+    def test_merged_points_no_identifiers(self):
+        """Without identifiers, merged points still produce only one coverage (no duplication)."""
+        request = {
+            "class": "od",
+            "stream": "enfo",
+            "type": "pf",
+            "date": self.date,
+            "time": "0000",
+            "levtype": "sfc",
+            "expver": "0001",
+            "domain": "g",
+            "param": "167",
+            "number": "1",
+            "feature": {
+                "type": "timeseries",
+                # Two points that snap to same grid point, no identifiers
+                "points": [[-9.10, 38.78], [-9.11, 38.79]],
+                "time_axis": "step",
+                "axes": ["latitude", "longitude"],
+                "range": {"start": 0, "end": 3},
+            },
+        }
+        try:
+            result = PolytopeMars(self.cf).extract(request)
+        except Exception as e:
+            if "GribJump" in str(type(e).__name__) or "fdb" in str(e).lower() or "gribjump" in str(e).lower():
+                pytest.skip("GribJump/FDB not available for integration test")
+            raise
+
+        coverages = result["coverages"]
+        # Without identifiers, merged points produce a single coverage (polytope deduplication)
+        assert len(coverages) == 1
+        assert "identifier" not in coverages[0]["mars:metadata"]

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,4 +1,4 @@
-"""Tests for the optional 'identifiers' field in the timeseries feature dictionary."""
+"""Tests for the optional 'labels' field in the timeseries feature dictionary."""
 
 import copy
 from datetime import datetime, timedelta
@@ -34,7 +34,7 @@ class TestIdentifiersValidation:
             "feature": {
                 "type": "timeseries",
                 "points": [[-9.10, 38.78], [51.5, 6.5]],
-                "identifiers": ["Lisbon", "Dusseldorf"],
+                "labels": ["Lisbon", "Dusseldorf"],
                 "time_axis": "step",
                 "axes": ["latitude", "longitude"],
                 "range": {"start": 0, "end": 3},
@@ -119,56 +119,56 @@ class TestIdentifiersValidation:
     # -- Basic acceptance tests --
 
     def test_identifiers_accepted_in_feature_config(self):
-        """Identifiers field is accepted without error when count matches points."""
+        """Labels field is accepted without error when count matches points."""
         preq, feature = self._build_request_shapes(self.request)
         assert feature.identifiers == ["Lisbon", "Dusseldorf"]
 
     def test_identifiers_none_when_not_provided(self):
-        """When identifiers is omitted, feature.identifiers is None."""
+        """When labels is omitted, feature.identifiers is None."""
         request = copy.deepcopy(self.request)
-        del request["feature"]["identifiers"]
+        del request["feature"]["labels"]
         preq, feature = self._build_request_shapes(request)
         assert feature.identifiers is None
 
     def test_identifiers_single_point(self):
-        """Identifiers works with a single point."""
+        """Labels works with a single point."""
         request = copy.deepcopy(self.request)
         request["feature"]["points"] = [[48.0, 11.0]]
-        request["feature"]["identifiers"] = ["Munich"]
+        request["feature"]["labels"] = ["Munich"]
         preq, feature = self._build_request_shapes(request)
         assert feature.identifiers == ["Munich"]
 
     def test_identifiers_many_points(self):
-        """Identifiers works with many points."""
+        """Labels works with many points."""
         request = copy.deepcopy(self.request)
         points = [[-9.10, 38.78], [51.5, 6.5], [48.0, 11.0], [40.4, -3.7]]
         identifiers = ["Lisbon", "Dusseldorf", "Munich", "Madrid"]
         request["feature"]["points"] = points
-        request["feature"]["identifiers"] = identifiers
+        request["feature"]["labels"] = identifiers
         preq, feature = self._build_request_shapes(request)
         assert feature.identifiers == identifiers
 
     # -- Validation error tests --
 
     def test_identifiers_mismatch_too_few(self):
-        """Raises ValueError when fewer identifiers than points."""
+        """Raises ValueError when fewer labels than points."""
         request = copy.deepcopy(self.request)
-        request["feature"]["identifiers"] = ["Lisbon"]  # only 1, but 2 points
-        with pytest.raises(ValueError, match="Number of identifiers"):
+        request["feature"]["labels"] = ["Lisbon"]  # only 1, but 2 points
+        with pytest.raises(ValueError, match="Number of labels"):
             self._build_request_shapes(request)
 
     def test_identifiers_mismatch_too_many(self):
-        """Raises ValueError when more identifiers than points."""
+        """Raises ValueError when more labels than points."""
         request = copy.deepcopy(self.request)
-        request["feature"]["identifiers"] = ["Lisbon", "Dusseldorf", "Munich"]  # 3, but 2 points
-        with pytest.raises(ValueError, match="Number of identifiers"):
+        request["feature"]["labels"] = ["Lisbon", "Dusseldorf", "Munich"]  # 3, but 2 points
+        with pytest.raises(ValueError, match="Number of labels"):
             self._build_request_shapes(request)
 
     def test_identifiers_empty_list_with_points(self):
-        """Raises ValueError when identifiers is empty but points exist."""
+        """Raises ValueError when labels is empty but points exist."""
         request = copy.deepcopy(self.request)
-        request["feature"]["identifiers"] = []
-        with pytest.raises(ValueError, match="Number of identifiers"):
+        request["feature"]["labels"] = []
+        with pytest.raises(ValueError, match="Number of labels"):
             self._build_request_shapes(request)
 
     # -- Shape construction tests --
@@ -196,9 +196,9 @@ class TestIdentifiersValidation:
         assert tags == ["Lisbon", "Dusseldorf"]
 
     def test_no_identifiers_means_no_tags(self):
-        """When identifiers is not provided, Point shapes have tag=None."""
+        """When labels is not provided, Point shapes have tag=None."""
         request = copy.deepcopy(self.request)
-        del request["feature"]["identifiers"]
+        del request["feature"]["labels"]
         preq, feature = self._build_request_shapes(request)
 
         union_shape = None
@@ -213,11 +213,11 @@ class TestIdentifiersValidation:
             assert p.tag is None
 
     def test_identifiers_with_swapped_axes(self):
-        """Identifiers work correctly when axes are [longitude, latitude]."""
+        """Labels work correctly when axes are [longitude, latitude]."""
         request = copy.deepcopy(self.request)
         request["feature"]["axes"] = ["longitude", "latitude"]
         request["feature"]["points"] = [[38.78, -9.10], [6.5, 51.5]]
-        request["feature"]["identifiers"] = ["Lisbon", "Dusseldorf"]
+        request["feature"]["labels"] = ["Lisbon", "Dusseldorf"]
         preq, feature = self._build_request_shapes(request)
 
         union_shape = None
@@ -232,9 +232,9 @@ class TestIdentifiersValidation:
         assert tags == ["Lisbon", "Dusseldorf"]
 
     def test_identifiers_numeric_values(self):
-        """Identifiers can be numeric (e.g. station IDs)."""
+        """Labels can be numeric (e.g. station IDs)."""
         request = copy.deepcopy(self.request)
-        request["feature"]["identifiers"] = [12345, 67890]
+        request["feature"]["labels"] = [12345, 67890]
         preq, feature = self._build_request_shapes(request)
 
         union_shape = None
@@ -248,10 +248,10 @@ class TestIdentifiersValidation:
         assert tags == [12345, 67890]
 
     def test_identifiers_not_allowed_without_points(self):
-        """If points is empty but identifiers is provided, validation fails."""
+        """If points is empty but labels is provided, validation fails."""
         request = copy.deepcopy(self.request)
         request["feature"]["points"] = []
-        request["feature"]["identifiers"] = ["Lisbon"]
+        request["feature"]["labels"] = ["Lisbon"]
         # This should fail because points is empty but identifiers has values
         # The parse step will fail because points[0] doesn't exist
         with pytest.raises((ValueError, IndexError)):
@@ -322,7 +322,7 @@ class TestIdentifiersIntegration:
         self.cf["options"] = self.options
 
     def test_extract_with_identifiers(self):
-        """Full extract pipeline accepts identifiers without error."""
+        """Full extract pipeline accepts labels without error."""
         request = {
             "class": "od",
             "stream": "enfo",
@@ -337,7 +337,7 @@ class TestIdentifiersIntegration:
             "feature": {
                 "type": "timeseries",
                 "points": [[-9.10, 38.78], [51.5, 6.5]],
-                "identifiers": ["Lisbon", "Dusseldorf"],
+                "labels": ["Lisbon", "Dusseldorf"],
                 "time_axis": "step",
                 "axes": ["latitude", "longitude"],
                 "range": {"start": 0, "end": 3},
@@ -353,7 +353,7 @@ class TestIdentifiersIntegration:
             raise
 
     def test_extract_without_identifiers_still_works(self):
-        """Full extract pipeline still works when identifiers is not provided."""
+        """Full extract pipeline still works when labels is not provided."""
         request = {
             "class": "od",
             "stream": "enfo",
@@ -382,7 +382,7 @@ class TestIdentifiersIntegration:
             raise
 
     def test_merged_points_duplicate_coverages(self):
-        """When two points snap to the same grid cell, each identifier gets its own coverage."""
+        """When two points snap to the same grid cell, each label gets its own coverage."""
         request = {
             "class": "od",
             "stream": "enfo",
@@ -398,7 +398,7 @@ class TestIdentifiersIntegration:
                 "type": "timeseries",
                 # Two points very close together (snap to same grid point) + one distinct
                 "points": [[-9.10, 38.78], [-9.11, 38.79], [51.5, 6.5]],
-                "identifiers": ["Lisbon_StationA", "Lisbon_StationB", "Dusseldorf"],
+                "labels": ["Lisbon_StationA", "Lisbon_StationB", "Dusseldorf"],
                 "time_axis": "step",
                 "axes": ["latitude", "longitude"],
                 "range": {"start": 0, "end": 3},
@@ -416,11 +416,11 @@ class TestIdentifiersIntegration:
         # Should get 3 coverages even though only 2 unique grid points
         assert len(coverages) == 3
 
-        # Collect identifiers from all coverages
-        identifiers = [c["mars:metadata"]["identifier"] for c in coverages]
-        assert "Lisbon_StationA" in identifiers
-        assert "Lisbon_StationB" in identifiers
-        assert "Dusseldorf" in identifiers
+        # Collect labels from all coverages
+        labels = [c["mars:metadata"]["label"] for c in coverages]
+        assert "Lisbon_StationA" in labels
+        assert "Lisbon_StationB" in labels
+        assert "Dusseldorf" in labels
 
     def test_merged_points_same_data(self):
         """Coverages for merged points have identical data values."""
@@ -439,7 +439,7 @@ class TestIdentifiersIntegration:
                 "type": "timeseries",
                 # Two points that will snap to the same grid point
                 "points": [[-9.10, 38.78], [-9.11, 38.79]],
-                "identifiers": ["StationA", "StationB"],
+                "labels": ["StationA", "StationB"],
                 "time_axis": "step",
                 "axes": ["latitude", "longitude"],
                 "range": {"start": 0, "end": 3},
@@ -469,14 +469,14 @@ class TestIdentifiersIntegration:
         values_b = coverages[1]["ranges"][param_key]["values"]
         assert values_a == values_b
 
-        # But different identifiers
-        id_a = coverages[0]["mars:metadata"]["identifier"]
-        id_b = coverages[1]["mars:metadata"]["identifier"]
+        # But different labels
+        id_a = coverages[0]["mars:metadata"]["label"]
+        id_b = coverages[1]["mars:metadata"]["label"]
         assert id_a != id_b
         assert {id_a, id_b} == {"StationA", "StationB"}
 
     def test_merged_points_no_identifiers(self):
-        """Without identifiers, merged points still produce only one coverage (no duplication)."""
+        """Without labels, merged points still produce only one coverage (no duplication)."""
         request = {
             "class": "od",
             "stream": "enfo",
@@ -505,6 +505,6 @@ class TestIdentifiersIntegration:
             raise
 
         coverages = result["coverages"]
-        # Without identifiers, merged points produce a single coverage (polytope deduplication)
+        # Without labels, merged points produce a single coverage (polytope deduplication)
         assert len(coverages) == 1
-        assert "identifier" not in coverages[0]["mars:metadata"]
+        assert "label" not in coverages[0]["mars:metadata"]


### PR DESCRIPTION
### Description

Adds an optional `"labels"` field to the timeseries feature dictionary. This allows users to assign meaningful names (e.g. station IDs, city names) to each point in a multi-point `timeseries` request.


### API Change
The feature dictionary for `timeseries` now accepts an optional `"labels"` key — a list of values that must align 1:1 with the `"points"` list.

Example request:
```
{
  "class": "od",
  "stream": "enfo",
  "type": "pf",
  "date": "20260618",
  "time": "0000",
  "levtype": "sfc",
  "expver": "0001",
  "domain": "g",
  "param": "167",
  "number": "1",
  "feature": {
    "type": "timeseries",
    "points": [[-9.10, 38.78], [51.5, 6.5], [48.0, 11.0]],
    "labels": ["Lisbon", "Dusseldorf", "Munich"],
    "time_axis": "step",
    "axes": ["latitude", "longitude"],
    "range": {"start": 0, "end": 3}
  }
}
```

Example output (per coverage in CoverageJSON):
```
{
  "mars:metadata": {
    "class": "od",
    "Forecast date": "2026-06-18T00:00:00Z",
    "number": 1,
    "levelist": 0,
    "label": "Lisbon"
  }
}
```
### Behaviour
- Each label is passed as a tag to the corresponding shapes.Point() in the polytope request (requires polytope PR #530 (https://github.com/ecmwf/polytope/pull/530)).
- Labels propagate through the polytope result tree and are surfaced in the CoverageJSON output as "label" in mars:metadata for each coverage.
- When multiple points resolve to the same nearest grid cell, separate coverages are emitted — one per label — with identical data but distinct identifiers.
- When "labels" is omitted, behaviour is unchanged (backwards compatible).

### Validation
- len(labels) must equal len(points) — raises ValueError otherwise.
- The field is fully optional; existing requests without "labels" continue to work.

### Dependencies
- Requires polytope tag support: ecmwf/polytope#530 (https://github.com/ecmwf/polytope/pull/530)
- covjsonkit (feature/add_identifiers (https://github.com/ecmwf/covjsonkit/tree/feature/add_identifiers) branch):
  - covjsonkit/encoder/encoder.py: Add collect_tags() helper in walk_tree() that reads tree.tags from latitude/leaf nodes and stores them per-point in fields["identifiers"]
  - covjsonkit/encoder/TimeSeries.py: Initialize fields["labels"], emit duplicate coverages when multiple labels map to the same grid point, add "label" to mars:metadata

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
