### PR TITLE
Add change to enforce west > east convention for bounding box points

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   <a href="#concept">Concept</a> •
   <a href="#installation">Installation</a> •
   <a href="#example">Example</a> •
+  <a href="#features">Features</a> •
   <a href="#testing">Testing</a>
 </p>
 
@@ -37,6 +38,11 @@ Current features include:
 * [Trajectory](docs/user_guide/trajectory.md)
 * [Polygon](docs/user_guide/polygon.md)
 * [Frame](docs/user_guide/frame.md)
+* [Circle](#circle)
+* [Position](#position)
+* [Shapefile](#shapefile)
+
+See [Features](#features) below for a request example of each.
 
 > \[!IMPORTANT\]
 > This software is **Incubating** and subject to ECMWF's guidelines on [Software Maturity](https://github.com/ecmwf/codex/raw/refs/heads/main/Project%20Maturity).
@@ -138,6 +144,171 @@ An example config can be found here [example_config.json](example_config.json). 
 2. **options** These are the options used by polytope for interpreting the data available.
 3. **coverageconfig** These options are used by convjsonkit to parse the output of polytope into coverageJSON.
 
+
+## Features
+
+Every request contains a `feature` dictionary describing the geometry to
+extract, alongside the usual MARS keywords (`class`, `stream`, `param`, `date`,
+`step`, ...). The examples below show only the `feature` block; drop it into the
+base request shown in the [Example](#example) section above.
+
+By default the coordinate axes are `["latitude", "longitude"]`, so each point is
+given as `[latitude, longitude]`. Many features accept an optional `axes` key to
+add `levelist` and/or `step`.
+
+### Time Series
+
+A single point extracted over a range of steps (or dates). See the
+[Time Series docs](docs/user_guide/timeseries.md).
+
+```python
+"feature": {
+    "type": "timeseries",
+    "points": [[-9.10, 38.78]],   # [latitude, longitude]
+    "axes": "step",
+}
+```
+
+### Vertical Profile
+
+A single point extracted over all levels. Requires an upper-air `levtype`
+(e.g. `pl`). See the [Vertical Profile docs](docs/user_guide/vertical_profile.md).
+
+```python
+"feature": {
+    "type": "verticalprofile",
+    "points": [[-9.10, 38.78]],   # [latitude, longitude]
+    "axes": "levelist",
+}
+```
+
+### Bounding Box
+
+All grid points inside a latitude/longitude rectangle. See the
+[Bounding Box docs](docs/user_guide/boundingbox.md).
+
+```python
+"feature": {
+    "type": "boundingbox",
+    "points": [[-1, -1], [1, 1]],   # [[south, west], [north, east]]
+}
+```
+
+**Point semantics (important):** the two points are the box corners in the fixed
+order `[[south, west], [north, east]]` — the lower-left (south-west) corner
+first, then the upper-right (north-east) corner. This matches the OGC EDR
+lower-left / upper-right corner convention.
+
+* Latitude must satisfy `south <= north` and lie within `[-90, 90]`.
+* Longitudes may be supplied signed (`[-180, 180]`) or wrapped (`[0, 360)`);
+  they are normalised internally, so the same box can be given either way.
+* The box is always the arc swept **eastward** from the west edge to the east
+  edge, so the order of the two longitudes selects the region.
+* Meridian- and antimeridian-crossing boxes are handled automatically — no need
+  to split the request:
+
+```python
+# ordinary box (west < east)
+"points": [[0, 10], [1, 20]]
+# crosses the prime meridian, signed longitudes (west < east)
+"points": [[-1, -0.1], [1, 0.1]]
+# same box using wrapped longitudes (west = 359.9 > east = 0.1, normalised internally)
+"points": [[-1, 359.9], [1, 0.1]]
+# crosses the antimeridian (split internally at ±180)
+"points": [[-1, 179.9], [1, -179.9]]
+```
+
+An optional third axis adds a level range, with corners
+`[[south, west, level_1], [north, east, level_2]]`:
+
+```python
+"feature": {
+    "type": "boundingbox",
+    "points": [[-1, -1, 1000], [1, 1, 500]],
+    "axes": ["latitude", "longitude", "levelist"],
+}
+```
+
+### Trajectory
+
+Points along a path, each inflated by a `Box` (or disk/ellipsoid) of the given
+`inflation`. Points are `[latitude, longitude, levelist, step]` by default. See
+the [Trajectory docs](docs/user_guide/trajectory.md).
+
+```python
+"feature": {
+    "type": "trajectory",
+    "points": [[-1, -1, 1000, 0], [0, 0, 1000, 12], [1, 1, 250, 24]],
+    "inflation": 0.1,
+    "inflate": "box",
+}
+```
+
+### Polygon
+
+All grid points inside one or more polygons. Each vertex is
+`[latitude, longitude]`; the ring should be closed (first vertex repeated). See
+the [Polygon docs](docs/user_guide/polygon.md).
+
+```python
+"feature": {
+    "type": "polygon",
+    "shape": [[-1, 1], [-1, 0], [0, 1], [-1, 1]],
+}
+```
+
+Multiple polygons can be requested by nesting a list of rings:
+
+```python
+"shape": [[[-1, 1], [-1, 0], [0, 1], [-1, 1]], [[-2, 2], [-2, 1], [1, 2], [-2, 2]]]
+```
+
+### Frame
+
+A hollow rectangular band between an inner and an outer box. Each corner is
+`[latitude, longitude]`.
+
+```python
+"feature": {
+    "type": "frame",
+    "outer_box": [[-2, -2], [2, 2]],   # [[south, west], [north, east]]
+    "inner_box": [[-1, -1], [1, 1]],
+}
+```
+
+### Circle
+
+All grid points within a `radius` (in degrees) of a `center` point.
+
+```python
+"feature": {
+    "type": "circle",
+    "center": [[0, 0]],   # [[latitude, longitude]]
+    "radius": 1,
+}
+```
+
+### Position
+
+The nearest grid point to each requested point, returned as a point series.
+
+```python
+"feature": {
+    "type": "position",
+    "points": [[-9.10, 38.78], [51.5, 0.1]],   # [latitude, longitude]
+}
+```
+
+### Shapefile
+
+All grid points inside the geometry of a shapefile on disk.
+
+```python
+"feature": {
+    "type": "shapefile",
+    "file": "path/to/shape.shp",
+}
+```
 
 ## Acknowledgements
 

--- a/polytope_mars/features/boundingbox.py
+++ b/polytope_mars/features/boundingbox.py
@@ -3,7 +3,7 @@ import logging
 from polytope_feature import shapes
 
 from ..feature import Feature
-from ..utils.areas import field_area, get_boundingbox_area
+from ..utils.areas import field_area, get_boundingbox_area, normalise_lon
 
 
 class BoundingBox(Feature):
@@ -27,47 +27,57 @@ class BoundingBox(Feature):
         logging.info(f"Area of bounding box: {self.area_bb} km\u00b2")
 
     def get_shapes(self):
-        # Time-series is a squashed box from start_step to start_end for each point  # noqa: E501
-        if len(self.points[0]) == 2:
-            return [
-                shapes.Union(
-                    ["latitude", "longitude"],
-                    *[
-                        shapes.Box(
-                            ["latitude", "longitude"],
-                            lower_corner=[
-                                self.points[0][self.axes.index("latitude")],
-                                self.points[0][self.axes.index("longitude")],
-                            ],  # noqa: E501
-                            upper_corner=[
-                                self.points[1][self.axes.index("latitude")],
-                                self.points[1][self.axes.index("longitude")],
-                            ],  # noqa: E501
-                        )
-                    ],
-                )
-            ]
+        # Bounding box is a Union of one or more axis-aligned Boxes.
+        # The longitude axis is cyclic ([0, 360)); a single Box collapses to an
+        # axis-aligned interval [min(lon), max(lon)] and loses sweep direction.
+        # We therefore normalise/split lazily, only when the west edge is
+        # numerically greater than the east edge (see bbox_convention.md):
+        #   * W < E            -> pass through untouched, single Box
+        #   * W > E, W' < E'   -> normalise to signed lons, single Box
+        #   * W > E, W' > E'   -> antimeridian crossing, Union of two Boxes
+        # where W'/E' are the signed-normalised longitudes. This is agnostic to
+        # the number of axes (2D lat/lon or 3D lat/lon/levelist): the split only
+        # touches the longitude component, everything else rides along unchanged.
+        # Preserve the exact shape ordering the previous implementation used so
+        # that non-crossing boxes are byte-for-byte identical to before:
+        #   * 2D: shape axes are always ["latitude", "longitude"], corners
+        #         reordered by name.
+        #   * 3D: shape axes are self.axes, corners taken positionally.
+        # The only new behaviour is the longitude split below.
+        if len(self.axes) == 2:
+            shape_axes = ["latitude", "longitude"]
+            lower = [self.points[0][self.axes.index(a)] for a in shape_axes]
+            upper = [self.points[1][self.axes.index(a)] for a in shape_axes]
         else:
-            return [
-                shapes.Union(
-                    [self.axes[0], self.axes[1], self.axes[2]],
-                    *[
-                        shapes.Box(
-                            [self.axes[0], self.axes[1], self.axes[2]],
-                            lower_corner=[
-                                self.points[0][0],
-                                self.points[0][1],
-                                self.points[0][2],
-                            ],
-                            upper_corner=[
-                                self.points[1][0],
-                                self.points[1][1],
-                                self.points[1][2],
-                            ],
-                        )
-                    ],
-                )
-            ]
+            shape_axes = list(self.axes)
+            lower = list(self.points[0])
+            upper = list(self.points[1])
+
+        lon_idx = shape_axes.index("longitude")
+        w = lower[lon_idx]
+        e = upper[lon_idx]
+
+        def make_box(lon_lower, lon_upper):
+            lc = list(lower)
+            uc = list(upper)
+            lc[lon_idx] = lon_lower
+            uc[lon_idx] = lon_upper
+            return shapes.Box(shape_axes, lower_corner=lc, upper_corner=uc)
+
+        if w < e:
+            # Already sweeping west -> east; the AABB is the intended region.
+            boxes = [make_box(w, e)]
+        else:
+            w_signed = normalise_lon(w)
+            e_signed = normalise_lon(e)
+            if w_signed < e_signed:
+                # Meridian crossing resolved by signed normalisation.
+                boxes = [make_box(w_signed, e_signed)]
+            else:
+                # Antimeridian crossing: split at +/-180 into two Boxes.
+                boxes = [make_box(w_signed, 180), make_box(-180, e_signed)]
+
+        return [shapes.Union(shape_axes, *boxes)]
 
     def incompatible_keys(self):
         return []
@@ -111,6 +121,18 @@ class BoundingBox(Feature):
 
         if len(feature_config["points"]) != 2:
             raise ValueError("Bounding box must have only two points in points")  # noqa: E501
+
+        # Latitude must be ordered south <= north and within [-90, 90].
+        # Longitudes are intentionally not range/order checked here: any value
+        # maps onto the cyclic longitude axis, and west > east is a valid
+        # meridian/antimeridian crossing handled in get_shapes().
+        lat_idx = self.axes.index("latitude")
+        s = self.points[0][lat_idx]
+        n = self.points[1][lat_idx]
+        if not (-90 <= s <= 90) or not (-90 <= n <= 90):
+            raise ValueError(f"Bounding box latitudes must be in [-90, 90] (got south={s}, north={n})")  # noqa: E501
+        if s > n:
+            raise ValueError(f"Bounding box requires south ({s}) <= north ({n})")  # noqa: E501
         if "axis" in feature_config:
             raise ValueError("Bounding box does not have axis in feature, did you mean axes?")  # noqa: E501
         if "axes" not in feature_config:

--- a/polytope_mars/features/polygon.py
+++ b/polytope_mars/features/polygon.py
@@ -46,6 +46,12 @@ class Polygons(Feature):
         assert len(feature_config) == 0, f"Unexpected keys in config: {feature_config.keys()}"
 
     def get_shapes(self):
+        # NOTE: Polygons share the cyclic-longitude datacube walker with
+        # BoundingBox and therefore have the same meridian/antimeridian-crossing
+        # failure mode (a shape whose longitudes straddle the 0/360 seam can
+        # over-select). Unlike BoundingBox, this cannot be fixed by a simple
+        # west/east split because it depends on vertex winding; it is
+        # intentionally out of scope here and handled by the caller for now.
         polygons = []
         for polygon in self.shape:
             points = []

--- a/polytope_mars/utils/areas.py
+++ b/polytope_mars/utils/areas.py
@@ -9,6 +9,16 @@ from shapely.ops import split
 from .datetimes import count_steps, days_between_dates, hours_between_times
 
 
+def normalise_lon(lon):
+    """
+    Normalise a longitude to the signed range [-180, 180].
+
+    :param lon: Longitude in degrees (any convention, e.g. [0, 360) or signed).
+    :return: The equivalent longitude in [-180, 180].
+    """
+    return ((lon + 180) % 360) - 180
+
+
 def haversine_distance(lat1, lon1, lat2, lon2):
     """
     Calculate the great-circle distance between two points on the Earth's surface.

--- a/tests/test_bounding_box_meridian.py
+++ b/tests/test_bounding_box_meridian.py
@@ -1,0 +1,174 @@
+import pytest
+
+from polytope_mars.config import PolytopeMarsConfig
+from polytope_mars.features.boundingbox import BoundingBox
+from polytope_mars.utils.areas import normalise_lon
+
+
+def _client_config():
+    return PolytopeMarsConfig()
+
+
+def _bbox(points, axes=None):
+    feature_config = {"type": "boundingbox", "points": [list(p) for p in points]}
+    if axes is not None:
+        feature_config["axes"] = list(axes)
+    return BoundingBox(feature_config, _client_config())
+
+
+def _boxes(bbox):
+    shapes = bbox.get_shapes()
+    assert len(shapes) == 1
+    union = shapes[0]
+    return list(union._shapes), union
+
+
+def _lon(box, axes):
+    i = list(box.axes()).index("longitude")
+    return box._lower_corner[i], box._upper_corner[i]
+
+
+def _legacy_shapes(points, axes):
+    """Reproduce the pre-change get_shapes() output exactly, to characterise
+    that non-crossing boxes are unchanged (only longitude values may differ)."""
+    from polytope_feature import shapes
+
+    if len(points[0]) == 2:
+        return [
+            shapes.Union(
+                ["latitude", "longitude"],
+                shapes.Box(
+                    ["latitude", "longitude"],
+                    lower_corner=[points[0][axes.index("latitude")], points[0][axes.index("longitude")]],
+                    upper_corner=[points[1][axes.index("latitude")], points[1][axes.index("longitude")]],
+                ),
+            )
+        ]
+    return [
+        shapes.Union(
+            [axes[0], axes[1], axes[2]],
+            shapes.Box(
+                [axes[0], axes[1], axes[2]],
+                lower_corner=[points[0][0], points[0][1], points[0][2]],
+                upper_corner=[points[1][0], points[1][1], points[1][2]],
+            ),
+        )
+    ]
+
+
+def _assert_box_equal(a, b):
+    assert list(a.axes()) == list(b.axes())
+    assert list(a._lower_corner) == list(b._lower_corner)
+    assert list(a._upper_corner) == list(b._upper_corner)
+
+
+class TestEquivalenceWithPrevious:
+    """The request handed to polytope must be identical to before, except that
+    a west>east box is normalised (and, if still crossing, split)."""
+
+    @pytest.mark.parametrize(
+        "points, axes",
+        [
+            ([[0, 10], [1, 20]], ["latitude", "longitude"]),  # ordinary 2D
+            ([[-1, 170], [1, 190]], ["latitude", "longitude"]),  # antimeridian in [0,360)
+            ([[-1, -0.1], [1, 0.1]], ["latitude", "longitude"]),  # signed prime-meridian, W<E
+            ([[0.2, 0.1], [0.3, 0.2]], ["longitude", "latitude"]),  # 2D lonlat axis order
+            ([[-1, 170, 1000], [1, 190, 500]], ["latitude", "longitude", "levelist"]),  # 3D
+        ],
+    )
+    def test_non_crossing_identical_to_previous(self, points, axes):
+        new = _bbox(points, axes=axes if axes != ["latitude", "longitude"] else None).get_shapes()
+        old = _legacy_shapes(points, axes)
+        assert len(new) == len(old) == 1
+        new_boxes = list(new[0]._shapes)
+        old_boxes = list(old[0]._shapes)
+        assert len(new_boxes) == len(old_boxes) == 1
+        assert list(new[0].axes()) == list(old[0].axes())
+        _assert_box_equal(new_boxes[0], old_boxes[0])
+
+    def test_normalised_box_differs_only_in_longitude(self):
+        # W=359.9 > E=0.1 : normalised to signed, but everything else identical
+        # to the legacy shape built from the *normalised* longitudes.
+        new = _bbox([[-1, 359.9], [1, 0.1]]).get_shapes()
+        legacy_norm = _legacy_shapes([[-1, -0.1], [1, 0.1]], ["latitude", "longitude"])
+        new_box = list(new[0]._shapes)[0]
+        old_box = list(legacy_norm[0]._shapes)[0]
+        assert list(new_box.axes()) == list(old_box.axes())
+        assert new_box._lower_corner == pytest.approx(old_box._lower_corner)
+        assert new_box._upper_corner == pytest.approx(old_box._upper_corner)
+
+
+class TestNormaliseLon:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [(0, 0), (180, -180), (-180, -180), (359.9, -0.1), (360, 0), (190, -170), (10, 10)],
+    )
+    def test_normalise(self, raw, expected):
+        assert normalise_lon(raw) == pytest.approx(expected)
+
+
+class TestBoundingBoxMeridian:
+    def test_ordinary_box_untouched(self):
+        # W < E -> single box, values passed through unchanged
+        boxes, _ = _boxes(_bbox([[0, 10], [1, 20]]))
+        assert len(boxes) == 1
+        assert _lon(boxes[0], ["latitude", "longitude"]) == (10, 20)
+
+    def test_antimeridian_in_0_360_untouched(self):
+        # 170 -> 190 stays within [0, 360) and W < E, so it is a single box
+        boxes, _ = _boxes(_bbox([[-1, 170], [1, 190]]))
+        assert len(boxes) == 1
+        assert _lon(boxes[0], ["latitude", "longitude"]) == (170, 190)
+
+    def test_prime_meridian_wrapped_normalised(self):
+        # W=359.9 > E=0.1 -> normalise to signed, single box straddling 0
+        boxes, _ = _boxes(_bbox([[-1, 359.9], [1, 0.1]]))
+        assert len(boxes) == 1
+        w, e = _lon(boxes[0], ["latitude", "longitude"])
+        assert w == pytest.approx(-0.1)
+        assert e == pytest.approx(0.1)
+
+    def test_prime_meridian_signed_single_box(self):
+        # Already signed and W < E -> untouched single box
+        boxes, _ = _boxes(_bbox([[-1, -0.1], [1, 0.1]]))
+        assert len(boxes) == 1
+        assert _lon(boxes[0], ["latitude", "longitude"]) == (-0.1, 0.1)
+
+    def test_antimeridian_splits_into_two_boxes(self):
+        # W=179.9 > E=-179.9 and stays W' > E' after normalising -> split
+        boxes, _ = _boxes(_bbox([[-1, 179.9], [1, -179.9]]))
+        assert len(boxes) == 2
+        lons = sorted(_lon(b, ["latitude", "longitude"]) for b in boxes)
+        assert lons[0][0] == pytest.approx(-180)
+        assert lons[0][1] == pytest.approx(-179.9)
+        assert lons[1][0] == pytest.approx(179.9)
+        assert lons[1][1] == pytest.approx(180)
+
+    def test_split_preserves_latitude(self):
+        boxes, _ = _boxes(_bbox([[-2, 179.9], [3, -179.9]]))
+        assert len(boxes) == 2
+        for b in boxes:
+            lat_i = list(b.axes()).index("latitude")
+            assert b._lower_corner[lat_i] == -2
+            assert b._upper_corner[lat_i] == 3
+
+    def test_split_preserves_levelist_3d(self):
+        # 3-axis crossing box: levelist bound must be preserved on both boxes
+        boxes, _ = _boxes(_bbox([[-1, 179.9, 1000], [1, -179.9, 500]], axes=["latitude", "longitude", "levelist"]))
+        assert len(boxes) == 2
+        for b in boxes:
+            lev_i = list(b.axes()).index("levelist")
+            assert b._lower_corner[lev_i] == 1000
+            assert b._upper_corner[lev_i] == 500
+
+
+class TestBoundingBoxValidation:
+    def test_south_greater_than_north_raises(self):
+        bbox = _bbox([[1, 10], [-1, 20]])
+        with pytest.raises(ValueError):
+            bbox.parse({"param": "164"}, {"type": "boundingbox", "points": [[1, 10], [-1, 20]]})
+
+    def test_latitude_out_of_range_raises(self):
+        bbox = _bbox([[-91, 10], [1, 20]])
+        with pytest.raises(ValueError):
+            bbox.parse({"param": "164"}, {"type": "boundingbox", "points": [[-91, 10], [1, 20]]})


### PR DESCRIPTION
Boxes crossing meridian now act correctly aligned with mars area keyword

### Description


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
